### PR TITLE
Create s3.tf

### DIFF
--- a/code/build/s3.tf
+++ b/code/build/s3.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_s3_bucket" "dev_s3" {
+  bucket_prefix = "dev-"
+
+  tags = {
+    Environment      = "Dev"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "dev_s3" {
+  bucket = aws_s3_bucket.dev_s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}


### PR DESCRIPTION
This pull request introduces infrastructure changes to set up an S3 bucket for the development environment in AWS. The changes include defining the AWS provider, creating an S3 bucket with a specific prefix and tags, and configuring ownership controls for the bucket.

### Infrastructure setup:

* [`code/build/s3.tf`](diffhunk://#diff-b628bb7f7812aa09b883c805f11bc11b0a964c991cbd93f258759ec38ce54887R1-R18): Added AWS provider configuration for the `us-west-2` region.
* [`code/build/s3.tf`](diffhunk://#diff-b628bb7f7812aa09b883c805f11bc11b0a964c991cbd93f258759ec38ce54887R1-R18): Created an S3 bucket with the prefix `dev-` and tagged it with `Environment: Dev`.
* [`code/build/s3.tf`](diffhunk://#diff-b628bb7f7812aa09b883c805f11bc11b0a964c991cbd93f258759ec38ce54887R1-R18): Configured S3 bucket ownership controls to set `BucketOwnerPreferred` as the object ownership rule.